### PR TITLE
Handle cross-origin images in dithering

### DIFF
--- a/components/examples/HalftoneImage.tsx
+++ b/components/examples/HalftoneImage.tsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import Dither from '@components/dither';
 import type { RGBColor } from '@lib/dither';
+import getSafeImageSrc from '@lib/getSafeImageSrc';
 import useThemeTwoColor from '@lib/useThemeTwoColor';
 
 export interface HalftoneImageProps extends React.HTMLAttributes<HTMLElement> {
@@ -34,23 +35,7 @@ const HalftoneImage: React.FC<HalftoneImageProps> = ({ src, alt = '', width = 32
   const { palette, hoverInk, ready } = useThemeTwoColor();
   const [active, setActive] = React.useState(false);
 
-  const safeSrc = React.useMemo(() => {
-    try {
-      if (!src) return '';
-      // Allow data/blob as-is
-      if (/^(data:|blob:)/i.test(src)) return src;
-      const u = new URL(src, typeof window !== 'undefined' ? window.location.href : 'http://localhost');
-      // Same-origin or relative: keep as-is
-      if (typeof window !== 'undefined' && u.origin === window.location.origin) return src;
-      // Proxy absolute http(s) to avoid tainted canvas
-      if (u.protocol === 'http:' || u.protocol === 'https:') {
-        return `/api/image-proxy?url=${encodeURIComponent(u.toString())}`;
-      }
-      return src;
-    } catch {
-      return src;
-    }
-  }, [src]);
+  const safeSrc = React.useMemo(() => getSafeImageSrc(src) ?? '', [src]);
 
   if (!ready || !palette) return null;
 

--- a/lib/getSafeImageSrc.ts
+++ b/lib/getSafeImageSrc.ts
@@ -1,0 +1,114 @@
+const ABSOLUTE_SCHEME_RE = /^[a-zA-Z][a-zA-Z\d+.-]*:/;
+
+export interface SafeImageSrcOptions {
+  /**
+   * Path to the proxy endpoint used for remote images. Defaults to `/api/image-proxy`.
+   * The value can be absolute or relative; relative paths will be treated as same-origin.
+   */
+  proxyEndpoint?: string;
+  /**
+   * If `false`, never proxy remote URLs and always return the original value.
+   */
+  allowProxy?: boolean;
+}
+
+/**
+ * Returns an image URL that is safe to use with a canvas by proxying cross-origin
+ * http(s) resources through the app's image proxy. Relative paths, same-origin
+ * absolute URLs, and data/blob URIs are returned untouched.
+ */
+export function getSafeImageSrc(src?: string | null, options: SafeImageSrcOptions = {}): string | undefined {
+  if (!src) return undefined;
+
+  const trimmed = src.trim();
+  if (!trimmed) return undefined;
+
+  const { proxyEndpoint = '/api/image-proxy', allowProxy = true } = options;
+  const normalizedProxy = normalizeProxyEndpoint(proxyEndpoint);
+
+  // Already proxied (relative form) – return as-is.
+  if (
+    proxyEndpoint &&
+    (trimmed.startsWith(normalizedProxy.endpoint) || trimmed.startsWith(normalizedProxy.path))
+  ) {
+    return trimmed;
+  }
+
+  // Preserve data/blob URLs – they are already safe for canvas usage.
+  if (/^(data:|blob:)/i.test(trimmed)) {
+    return trimmed;
+  }
+
+  const hasScheme = ABSOLUTE_SCHEME_RE.test(trimmed);
+  const isProtocolRelative = trimmed.startsWith('//');
+
+  // Plain relative URLs (e.g. "./foo.png", "images/foo.png") are same-origin.
+  if (!hasScheme && !isProtocolRelative) {
+    return trimmed;
+  }
+
+  let resolved: URL;
+  try {
+    const base = typeof window !== 'undefined' ? window.location.href : 'http://localhost/';
+    resolved = new URL(trimmed, base);
+  } catch {
+    return trimmed;
+  }
+
+  // Already proxied (absolute form).
+  if (proxyEndpoint && resolved.pathname.startsWith(normalizedProxy.path)) {
+    return trimmed;
+  }
+
+  const isHttp = resolved.protocol === 'http:' || resolved.protocol === 'https:';
+  if (!isHttp) {
+    return trimmed;
+  }
+
+  if (typeof window !== 'undefined' && resolved.origin === window.location.origin) {
+    // Same-origin absolute URL – no need to proxy.
+    return trimmed;
+  }
+
+  if (!allowProxy) {
+    return trimmed;
+  }
+
+  const target = normalizedProxy.endpoint || proxyEndpoint;
+  return `${target}?url=${encodeURIComponent(resolved.toString())}`;
+}
+
+function normalizeProxyEndpoint(endpoint: string): { endpoint: string; path: string } {
+  if (!endpoint) {
+    return { endpoint, path: endpoint };
+  }
+
+  if (endpoint.startsWith('http://') || endpoint.startsWith('https://')) {
+    try {
+      const url = new URL(endpoint);
+      const cleanedEndpoint = url.origin + trimTrailingSlash(url.pathname);
+      return {
+        endpoint: cleanedEndpoint,
+        path: trimTrailingSlash(url.pathname) || '/',
+      };
+    } catch {
+      return { endpoint, path: endpoint };
+    }
+  }
+
+  const path = endpoint.startsWith('/') ? endpoint : `/${endpoint}`;
+  return {
+    endpoint: path,
+    path: trimTrailingSlash(path) || '/',
+  };
+}
+
+function trimTrailingSlash(path: string): string {
+  if (!path) return path;
+  if (path.length > 1 && path.endsWith('/')) {
+    return path.replace(/\/+$/, '');
+  }
+  return path || '/';
+}
+
+export default getSafeImageSrc;

--- a/lib/getSafeImageSrc.ts
+++ b/lib/getSafeImageSrc.ts
@@ -108,7 +108,7 @@ function trimTrailingSlash(path: string): string {
   if (path.length > 1 && path.endsWith('/')) {
     return path.replace(/\/+$/, '');
   }
-  return path || '/';
+  return path;
 }
 
 export default getSafeImageSrc;


### PR DESCRIPTION
## Summary
- add a shared `getSafeImageSrc` helper to proxy remote images through the local API when needed
- update the `Dither` component to use the helper, reset caches, and surface a warning when canvas pixels are unavailable
- reuse the helper in `Avatar` and `HalftoneImage` so all halftone consumers share the same CORS-safe logic

## Testing
- npx tsc --noEmit


------
https://chatgpt.com/codex/tasks/task_e_68d2dd9c7e008327af3348d83d2f3693