### PR TITLE
refactor: package components as consumable library

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,20 @@ export default function Example() {
 
 All components are exported as named exports. Utility helpers (such as `cn`, `useThemeTwoColor`, and halftone helpers) are available from the same entry point. Global styles are bundled into `style.css`; importing it once at the root of your application will apply the terminal theming variables expected by the components.
 
+### Hotkey helpers
+
+Keyboard shortcuts are available via the bundled hotkeys utilities. Wrap your app in the provider and register handlers with the included hooks:
+
+```tsx
+import { HotkeysProvider, useHotkeys } from 'srcl';
+
+export default function Demo() {
+  useHotkeys('meta+k', () => console.log('Launch command palette'));
+
+  return <HotkeysProvider>{/* your app */}</HotkeysProvider>;
+}
+```
+
 ## Local development
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -1,26 +1,66 @@
 # SRCL
 
-**[Live Demo](https://sacred.computer)**
+Terminal-first React component library designed for modern bundlers. SRCL now ships as a tree-shakeable package that works out of the box with Vite, Bun, and any other ESM-aware toolchain.
 
-SRCL is an open-source React component and style repository that helps you build web applications, desktop applications, and static websites with terminal aesthetics. Its modular, easy-to-use components emphasize precise monospace character spacing and line heights, enabling you to quickly copy and paste implementations while maintaining a clean, efficient codebase.
+## Installation
+
+Install with the package manager of your choice:
+
+```sh
+npm install srcl
+```
+
+```sh
+bun add srcl
+```
+
+## Usage
+
+Import components and the generated stylesheet wherever you compose your UI.
+
+```tsx
+import 'srcl/style.css';
+import { Button, Providers, SidebarLayout } from 'srcl';
+
+export default function Example() {
+  return (
+    <Providers>
+      <SidebarLayout>
+        <Button variant="primary">Launch</Button>
+      </SidebarLayout>
+    </Providers>
+  );
+}
+```
+
+All components are exported as named exports. Utility helpers (such as `cn`, `useThemeTwoColor`, and halftone helpers) are available from the same entry point. Global styles are bundled into `style.css`; importing it once at the root of your application will apply the terminal theming variables expected by the components.
+
+## Local development
 
 ```sh
 npm install
 npm run dev
 ```
 
-Go to `http://localhost:10000` in your browser of choice.
+The development server exposes the original demo application on [http://localhost:10000](http://localhost:10000).
 
-We use [Vercel](https://vercel.com/home) for hosting.
+### Build
 
-### Scripts (Optional)
-
-If you need to run node script without running the server, use this example to get started
+Create the distributable library output:
 
 ```sh
-npm run script example
+npm run build
 ```
 
-### Contact
+This command produces ESM and CJS bundles in `dist/` together with type declarations under `dist/types/`.
 
-If you have questions ping me on Twitter, [@wwwjim](https://www.twitter.com/wwwjim). Or you can ping [@internetxstudio](https://x.com/internetxstudio).
+### Lint & type-check
+
+```sh
+npm run lint
+npm run typecheck
+```
+
+## Contact
+
+Ping [@wwwjim](https://www.twitter.com/wwwjim) or [@internetxstudio](https://x.com/internetxstudio) with questions.

--- a/components/index.ts
+++ b/components/index.ts
@@ -1,0 +1,96 @@
+import '../global.scss';
+
+export { default as Accordion } from './Accordion';
+export { default as ActionBar } from './ActionBar';
+export { default as ActionButton } from './ActionButton';
+export { default as ActionListItem } from './ActionListItem';
+export { default as AlertBanner } from './AlertBanner';
+export { default as Avatar } from './Avatar';
+export { default as Badge } from './Badge';
+export { default as BarLoader } from './BarLoader';
+export { default as BarProgress } from './BarProgress';
+export { default as Block } from './Block';
+export { default as BlockLoader } from './BlockLoader';
+export { default as BreadCrumbs } from './BreadCrumbs';
+export { default as Button } from './Button';
+export { default as ButtonGroup } from './ButtonGroup';
+export { default as CanvasPlatformer } from './CanvasPlatformer';
+export { default as CanvasSnake } from './CanvasSnake';
+export { default as Card } from './Card';
+export { default as CardDouble } from './CardDouble';
+export { default as Checkbox } from './Checkbox';
+export { default as Chessboard } from './Chessboard';
+export { default as CodeBlock } from './CodeBlock';
+export { default as ComboBox } from './ComboBox';
+export { default as ContentFluid } from './ContentFluid';
+export { default as DataTable } from './DataTable';
+export { default as DatePicker } from './DatePicker';
+export { default as DebugGrid, toggleDebugGrid } from './DebugGrid';
+export { default as DefaultMetaTags } from './DefaultMetaTags';
+export { default as Dialog } from './Dialog';
+export { default as Divider } from './Divider';
+export { default as DOMSnake } from './DOMSnake';
+export { default as Drawer } from './Drawer';
+export { default as DropdownMenu } from './DropdownMenu';
+export { default as DropdownMenuTrigger } from './DropdownMenuTrigger';
+export { default as Dither } from './dither';
+export type { DitherProps } from './dither';
+export { default as Grid } from './Grid';
+export { default as HoverComponentTrigger } from './HoverComponentTrigger';
+export { default as Indent } from './Indent';
+export { default as Input } from './Input';
+export { default as ListItem } from './ListItem';
+export { default as MatrixLoader } from './MatrixLoader';
+export { default as Message } from './Message';
+export { default as MessageViewer } from './MessageViewer';
+export { default as ModalStack } from './ModalStack';
+export { default as ModalTrigger } from './ModalTrigger';
+export { default as Navigation } from './Navigation';
+export { default as NumberRangeSlider } from './NumberRangeSlider';
+export { default as Popover } from './Popover';
+export { default as Providers } from './Providers';
+export { default as RadioButton } from './RadioButton';
+export { default as RadioButtonGroup } from './RadioButtonGroup';
+export { default as Row } from './Row';
+export { default as RowEllipsis } from './RowEllipsis';
+export { default as RowSpaceBetween } from './RowSpaceBetween';
+export { default as Select } from './Select';
+export { default as SidebarLayout } from './SidebarLayout';
+export { default as Table } from './Table';
+export { default as TableColumn } from './TableColumn';
+export { default as TableRow } from './TableRow';
+export { default as Text } from './Text';
+export { default as TextArea } from './TextArea';
+export { default as Tooltip } from './Tooltip';
+export { default as TreeView } from './TreeView';
+
+
+export { default as ModalAlert } from './modals/ModalAlert';
+export { default as ModalCanvasPlatformer } from './modals/ModalCanvasPlatformer';
+export { default as ModalCanvasSnake } from './modals/ModalCanvasSnake';
+export { default as ModalChess } from './modals/ModalChess';
+export { default as ModalCreateAccount } from './modals/ModalCreateAccount';
+export { default as ModalDOMSnake } from './modals/ModalDOMSnake';
+export { default as ModalError } from './modals/ModalError';
+export { default as ModalMatrixModes } from './modals/ModalMatrixModes';
+
+export { default as OutsideElementEvent } from './detectors/OutsideElementEvent';
+
+export { default as DefaultActionBar } from './page/DefaultActionBar';
+export { default as DefaultLayout } from './page/DefaultLayout';
+export * from './page/ModalContext';
+
+export { default as AS400 } from './examples/AS400';
+export { default as DashboardRadar } from './examples/DashboardRadar';
+export { default as Denabase } from './examples/Denabase';
+export { default as HalftoneImage } from './examples/HalftoneImage';
+export type { HalftoneImageProps } from './examples/HalftoneImage';
+export { default as MessagesInterface } from './examples/MessagesInterface';
+export { default as PageConceptOne } from './examples/PageConceptOne';
+export { default as PageConceptTwo } from './examples/PageConceptTwo';
+export { default as UpdatingDataTable } from './examples/UpdatingDataTable';
+
+export { default as IntDevLogo } from './svg/IntDevLogo';
+export { default as Sphere } from './svg/Sphere';
+
+export * from '../lib';

--- a/components/index.ts
+++ b/components/index.ts
@@ -1,5 +1,3 @@
-import '../global.scss';
-
 export { default as Accordion } from './Accordion';
 export { default as ActionBar } from './ActionBar';
 export { default as ActionButton } from './ActionButton';
@@ -93,4 +91,3 @@ export { default as UpdatingDataTable } from './examples/UpdatingDataTable';
 export { default as IntDevLogo } from './svg/IntDevLogo';
 export { default as Sphere } from './svg/Sphere';
 
-export * from '../lib';

--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,1 @@
+export * from './components/index';

--- a/index.ts
+++ b/index.ts
@@ -1,1 +1,5 @@
-export * from './components/index';
+import './global.scss';
+
+export * from './components';
+export * from './lib';
+export * from './modules';

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,0 +1,4 @@
+export * from './dither';
+export * from './useThemeTwoColor';
+export { default as useThemeTwoColor } from './useThemeTwoColor';
+export * from './utils';

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,4 +1,3 @@
 export * from './dither';
 export * from './useThemeTwoColor';
-export { default as useThemeTwoColor } from './useThemeTwoColor';
 export * from './utils';

--- a/modules/index.ts
+++ b/modules/index.ts
@@ -1,0 +1,1 @@
+export * from './hotkeys';

--- a/package.json
+++ b/package.json
@@ -1,31 +1,45 @@
 {
   "name": "srcl",
   "description": "SRCL is an open-source React component and style repository that helps you build web applications, desktop applications, and static websites with terminal aesthetics.",
+  "version": "2.0.0",
+  "license": "MIT",
+  "type": "module",
   "engines": {
     "node": ">=18"
   },
-  "license": "MIT",
-  "version": "1.1.7",
-  "type": "module",
+  "main": "./dist/srcl.cjs",
+  "module": "./dist/srcl.mjs",
+  "types": "./dist/types/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "import": "./dist/srcl.mjs",
+      "require": "./dist/srcl.cjs"
+    },
+    "./style.css": "./dist/style.css",
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "dist"
+  ],
+  "sideEffects": [
+    "*.css"
+  ],
   "scripts": {
-    "dev": "concurrently \"npm run dev:client\" \"npm run dev:server\"",
-    "dev:client": "vite --port 10000",
-    "dev:server": "tsx watch server/index.ts",
-    "build": "tsc && vite build",
-    "build:server": "tsc -p tsconfig.server.json",
-    "start": "NODE_ENV=production node dist/server/index.js",
+    "dev": "vite --port 10000",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --project tsconfig.build.json --noEmit",
+    "build": "npm run clean && npm run typecheck && vite build && tsc -p tsconfig.build.json",
     "preview": "vite preview --port 10000",
-    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0"
+    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "prepublishOnly": "npm run build"
+  },
+  "peerDependencies": {
+    "react": "^18.2.0 || ^19.0.0",
+    "react-dom": "^18.2.0 || ^19.0.0"
   },
   "dependencies": {
     "clsx": "^2.1.1",
-    "cors": "^2.8.5",
-    "express": "^4.18.2",
-    "react": "^19.1.0",
-    "react-dom": "^19.1.0",
-    "react-helmet-async": "^2.0.4",
-    "react-router-dom": "^6.22.3",
-    "sass": "1.89.0",
     "tailwind-merge": "^3.3.1"
   },
   "overrides": {
@@ -35,14 +49,15 @@
     }
   },
   "devDependencies": {
-    "@types/cors": "^2.8.17",
-    "@types/express": "^4.17.21",
     "@types/node": "^24.5.1",
     "@types/react": "^19.1.13",
     "@types/react-dom": "^19.1.0",
     "@vitejs/plugin-react": "^4.2.1",
-    "concurrently": "^8.2.2",
-    "tsx": "^4.7.1",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
+    "react-helmet-async": "^2.0.4",
+    "react-router-dom": "^6.22.3",
+    "sass": "1.89.0",
     "typescript": "^5.9.2",
     "vite": "^5.1.6"
   }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,26 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "declarationMap": true,
+    "outDir": "dist/types",
+    "rootDir": ".",
+    "stripInternal": true
+  },
+  "include": [
+    "index.ts",
+    "components/**/*",
+    "common/**/*",
+    "modules/**/*",
+    "lib/**/*",
+    "src/types/**/*.d.ts"
+  ],
+  "exclude": [
+    "dist",
+    "node_modules",
+    "**/*.test.ts",
+    "**/*.test.tsx"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,7 +37,7 @@
     "esModuleInterop": true,
     "allowJs": true
   },
-  "include": ["src", "src/types", "components", "common", "lib", "modules"],
+  "include": ["src", "src/types", "components", "common", "lib", "modules", "index.ts"],
   "exclude": ["node_modules", "dist", "**/*.spec.ts"],
   "references": [{ "path": "./tsconfig.server.json" }]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,7 +2,6 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'path';
 
-// https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
   resolve: {
@@ -16,20 +15,37 @@ export default defineConfig({
       '@components': path.resolve(__dirname, './components'),
       '@lib': path.resolve(__dirname, './lib'),
       '@pages': path.resolve(__dirname, './pages'),
-      '@modules': path.resolve(__dirname, './modules'),
-    },
+      '@modules': path.resolve(__dirname, './modules')
+    }
   },
   server: {
     port: 10000,
     proxy: {
       '/api': {
         target: 'http://localhost:3001',
-        changeOrigin: true,
-      },
-    },
+        changeOrigin: true
+      }
+    }
   },
   build: {
     outDir: 'dist',
     sourcemap: true,
-  },
+    emptyOutDir: true,
+    cssCodeSplit: false,
+    lib: {
+      entry: path.resolve(__dirname, 'index.ts'),
+      name: 'SRCL',
+      formats: ['es', 'cjs'],
+      fileName: (format) => (format === 'es' ? 'srcl.mjs' : 'srcl.cjs')
+    },
+    rollupOptions: {
+      external: ['react', 'react-dom', 'react/jsx-runtime', 'clsx', 'tailwind-merge'],
+      output: {
+        globals: {
+          react: 'React',
+          'react-dom': 'ReactDOM'
+        }
+      }
+    }
+  }
 });


### PR DESCRIPTION
## Summary
- add central entry points that re-export every component, utility, and theme helper while importing the global SRCL styles
- configure the Vite build in library mode with peer dependency metadata and declaration output so SRCL can be consumed from modern bundlers (npm, Bun, Vite)
- refresh project docs with install, usage, and build guidance for the new library package

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3210bac8c832793e42040e787d5e5