### PR TITLE
Fix halftone palette inversion for dark themes

### DIFF
--- a/components/Avatar.tsx
+++ b/components/Avatar.tsx
@@ -4,7 +4,7 @@ import Dither from '@components/dither';
 import * as React from 'react';
 import * as Utilities from '@common/utilities';
 import type { RGBColor } from '@lib/dither';
-import getSafeImageSrc from '@lib/getSafeImageSrc';
+import useThemeTwoColor from '@lib/useThemeTwoColor';
 
 interface AvatarProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'style' | 'className' | 'children'> {
   src?: string;
@@ -27,101 +27,8 @@ interface AvatarProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'style'
 const Avatar: React.FC<AvatarProps> = (props) => {
   const { src, alt, style: propStyle, href, target, children, ...rest } = props;
 
-  // Palette is [paper, baseInk] = [theme-background, theme-text]
-  const [palette, setPalette] = React.useState<RGBColor[] | undefined>();
-  // Hover ink (theme-focused-foreground)
-  const [hoverInk, setHoverInk] = React.useState<RGBColor | undefined>();
+  const { palette, hoverInk, ready } = useThemeTwoColor();
   const [active, setActive] = React.useState(false);
-
-  // Parse rgb/rgba strings into [r,g,b]
-  const parseColor = React.useCallback((colorStr: string | null | undefined): RGBColor | null => {
-    if (!colorStr) return null;
-    // Match rgb(r,g,b) or rgba(r,g,b,a)
-    const match = colorStr.match(/rgba?\(\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)(?:\s*,\s*([\d.]+)\s*)?\)/i);
-    if (!match) return null;
-    const r = Math.max(0, Math.min(255, Math.round(parseFloat(match[1]))));
-    const g = Math.max(0, Math.min(255, Math.round(parseFloat(match[2]))));
-    const b = Math.max(0, Math.min(255, Math.round(parseFloat(match[3]))));
-    return [r, g, b];
-  }, []);
-
-  // Compute theme-derived colors and set palette/hoverInk
-  React.useEffect(() => {
-    if (typeof window === 'undefined') return;
-
-    const compute = () => {
-      try {
-        // Create probe elements to resolve CSS variables to actual computed colors
-        const probeText = document.createElement('div'); // theme-text (base ink)
-        probeText.style.color = 'var(--theme-text)';
-
-        const probeFocus = document.createElement('div'); // theme-focused-foreground (hover ink)
-        probeFocus.style.color = 'var(--theme-focused-foreground)';
-
-        const probeBg = document.createElement('div'); // theme-background (paper)
-        probeBg.style.backgroundColor = 'var(--theme-background)';
-
-        document.body.append(probeText, probeFocus, probeBg);
-
-        const themeText = getComputedStyle(probeText).color.trim();
-        const themeFocus = getComputedStyle(probeFocus).color.trim();
-        const themeBg = getComputedStyle(probeBg).backgroundColor.trim();
-
-        document.body.removeChild(probeText);
-        document.body.removeChild(probeFocus);
-        document.body.removeChild(probeBg);
-
-        let textColor = parseColor(themeText);
-        let focusedColor = parseColor(themeFocus);
-        let backgroundColor = parseColor(themeBg);
-
-        // Fallback to body computed colors if needed
-        if (!textColor || !backgroundColor || !focusedColor) {
-          const bodyStyles = getComputedStyle(document.body);
-          textColor = textColor ?? parseColor(bodyStyles.color.trim());
-          backgroundColor = backgroundColor ?? parseColor(bodyStyles.backgroundColor.trim());
-          // If focus color not available, fallback to text color
-          focusedColor = focusedColor ?? textColor ?? focusedColor;
-        }
-
-        if (backgroundColor && textColor) {
-          setPalette([backgroundColor, textColor]);
-          setHoverInk(focusedColor ?? textColor);
-        } else {
-          // Final fallback: white paper, black ink
-          setPalette([
-            [255, 255, 255],
-            [0, 0, 0],
-          ]);
-          setHoverInk([0, 0, 0]);
-        }
-      } catch {
-        // Final fallback: white paper, black ink
-        setPalette([
-          [255, 255, 255],
-          [0, 0, 0],
-        ]);
-        setHoverInk([0, 0, 0]);
-      }
-    };
-
-    // Initial compute
-    compute();
-
-    // Recompute when theme (body class) changes
-    const observer = new MutationObserver((mutations) => {
-      for (const m of mutations) {
-        if (m.type === 'attributes' && m.attributeName === 'class') {
-          compute();
-          break;
-        }
-      }
-    });
-
-    observer.observe(document.body, { attributes: true, attributeFilter: ['class'] });
-
-    return () => observer.disconnect();
-  }, [parseColor]);
 
 
   // Trim the raw src once; Dither handles proxying/fallback logic internally.
@@ -130,7 +37,7 @@ const Avatar: React.FC<AvatarProps> = (props) => {
 
   let avatarElement: React.ReactNode;
 
-  if (imageSrc && palette) {
+  if (imageSrc && ready && palette) {
     const twoColor: [RGBColor, RGBColor] = [palette[0], active && hoverInk ? hoverInk : palette[1]];
     const ditherElement = <Dither src={imageSrc} alt={alt ?? ''} width={38} height={38} twoColor={twoColor} className={styles.ditherCanvas} />;
 


### PR DESCRIPTION
## Summary
- ensure the theme-driven two-color palette swaps paper/ink when the ink is lighter than the background and fall back to a darker hover ink
- refactor the Avatar component to consume the shared theme palette hook so it benefits from the new inversion logic

## Testing
- npm run lint *(fails: ESLint could not find a configuration file after the ESLint v9 migration)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_68d32c931d8c832784b8a052cd0106e2)